### PR TITLE
CUL v4.0.0 alpha.16-4 rebase (download dialog updates)

### DIFF
--- a/__tests__/src/culPlugins/mirador-downloaddialog/components/dialog/ImageDownloadLinks.test.js
+++ b/__tests__/src/culPlugins/mirador-downloaddialog/components/dialog/ImageDownloadLinks.test.js
@@ -1,0 +1,54 @@
+import userEvent from '@testing-library/user-event';
+import { Utils } from 'manifesto.js';
+import { render, screen } from '../../../../../utils/test-utils';
+import ImageDownloadLinks from '../../../../../../src/culPlugins/mirador-downloaddialog/components/dialog/ImageDownloadLinks';
+
+import { numCanvases, someCanvases } from '../../../../../../src/culPlugins/mirador-selectCollectionFolders/lib/canvases';
+import fixture from '../../../../../fixtures/version-2/019.json';
+
+/** create wrapper */
+function createWrapper(props) {
+  return render(
+    <ImageDownloadLinks
+      {...props}
+    />,
+  );
+}
+
+describe('ImageDownloadLinks', () => {
+  let manifesto;
+  const canvas = {
+    getCanonicalImageUri: vi.fn((width) => `https://www.example.com/iiif/12345/${width}/0/default.jpg`),
+  };
+  const label = 'This is the label';
+  const sizes = [
+    { height: 100, width: 200 },
+    { height: 300, width: 600 },
+    { height: 500, width: 1000 },
+  ];
+
+  it('renders the component', () => {
+    createWrapper({
+      canvas,
+      label,
+      sizes,
+      suppressDownload: false,
+    });
+
+    const downloadLinks = screen.queryAllByText(/\d+ x \d+ pixels/);
+    expect(downloadLinks).toHaveLength(3);
+  });
+
+  describe('when suppressedDownload is true', () => {
+    it('renders the component with a suppression message', () => {
+      createWrapper({
+        canvas,
+        label,
+        sizes,
+        suppressDownload: true,
+      });
+
+      expect(screen.queryAllByText(`suppressedDownloads: ${label}`)).toHaveLength(1);
+    });
+  });
+});

--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "dist/mirador.min.js",
-      "maxSize": "900 KB"
+      "maxSize": "1000 KB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "exports": {
     "./src": "./src/index.js",
     ".": {
-        "import": "./dist/mirador.es.js",
-        "require": "./dist/mirador.min.js"
+      "import": "./dist/mirador.es.js",
+      "require": "./dist/mirador.min.js"
     }
   },
   "scripts": {
@@ -46,7 +46,7 @@
     "copy-to-clipboard": "^3.3.1",
     "deepmerge": "^4.2.2",
     "dompurify": "^3.0.0",
-    "i18next": "^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0",
+    "i18next": "^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0 || ^25.0.0",
     "lodash": "^4.17.11",
     "manifesto.js": "^4.2.0",
     "merge-refs": "^1.3.0",

--- a/src/culPlugins/mirador-downloaddialog/components/dialog/ImageDownloadLinks.jsx
+++ b/src/culPlugins/mirador-downloaddialog/components/dialog/ImageDownloadLinks.jsx
@@ -34,19 +34,6 @@ const ImageDownloadLinks = ({
         <List>
           {sizes
             .sort((a, b) => b.width - a.width)
-            .slice(1)
-            .reduce(
-              (acc, { height, width }) => {
-                // only take sizes, where the difference between the last taken width
-                // and the current one is bigger than 500 pixels
-                if (acc[acc.length - 1].width - width >= 500) {
-                  acc.push({ height, width });
-                }
-                return acc;
-              },
-              // this represents the full size
-              [{ height: canvas.getHeight(), width: canvas.getWidth() }],
-            )
             .map(({ height, width }) => (
               <ListItem dense key={`${height}x${width}`}>
                 <ImageLink


### PR DESCRIPTION
This PR updates the download dialog so that it only serves sizes that our IIIF image API advertises as available.  Also includes a bundlewatch size increase to allow the project to build, and updates the i18next dependency to address a dependency error (which is also done in upstream Mirador).

CI fails in this branch because of some test errors in the Mirador upstream branch.  I have a parallel branch (https://github.com/cul/mirador/tree/cul-v4.0.0-alpha.16-4-rebase-WITH-TEST-FIX-CHERRY-PICK) that cherry picks a couple of test fixes from upstream and CI runs successfully with those in place (see: https://github.com/cul/mirador/actions/runs/17418739870).  We just don't want to merge them into this branch because it will complicate rebasing later on.